### PR TITLE
feat: Add ble_stat_experiment.py and enhance evkit_lib.py with new BLE experiment features

### DIFF
--- a/ble_stat_experiment.py
+++ b/ble_stat_experiment.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+import time
+import random
+import sys
+import os
+import threading
+from evkit_lib import (
+    init_device,
+    set_smart_manufacturer_payload,
+    get_adv_payload_details,
+    get_gacp,
+    print_adv_payload_details,  # legacy payload display, not used directly now
+    close_device,
+    ADType
+)
+
+# Experiment parameters
+payload_update_interval = 5  # seconds between payload updates
+display_refresh_rate = 60    # display refresh rate in Hz
+
+# Global cache for display text and its lock
+display_lock = threading.Lock()
+cached_display_text = "No data yet"
+
+# Global variable to select display mode ("payload" or "gacp")
+display_mode = "payload"
+
+# Global event to signal threads to stop.
+stop_event = threading.Event()
+
+def clear_screen():
+    """Clear the terminal screen in a cross-platform manner."""
+    if os.name == 'nt':
+        try:
+            import colorama
+            colorama.init()
+        except ImportError:
+            pass
+        os.system('cls')
+    else:
+        if sys.stdout.isatty():
+            sys.stdout.write("\033[H\033[J")
+            sys.stdout.flush()
+        else:
+            print("\n" * 100)
+
+def get_display_text() -> str:
+    """
+    Retrieves and formats the current advertising payload details
+    (if in 'payload' mode) or the extended advertising parameters (if in 'gacp' mode)
+    into a multi-line string.
+    """
+    global display_mode
+    if display_mode == "payload":
+        raw_payload, fields = get_adv_payload_details()
+        lines = []
+        if raw_payload:
+            payload_size = len(raw_payload) // 2
+            lines.append("Raw Payload: " + raw_payload)
+            lines.append(f"Total Raw Payload Size: {payload_size} bytes\n")
+            for idx, (length, ad_type, data) in enumerate(fields, start=1):
+                try:
+                    ad_enum = ADType(ad_type)
+                    desc = ad_enum.name.replace("_", " ").title()
+                except ValueError:
+                    desc = "Unknown"
+                if ad_type == ADType.MANUFACTURER_SPECIFIC_DATA.value:
+                    company_id = data[:4]
+                    additional_data = data[4:]
+                    try:
+                        data_bytes = bytes.fromhex(additional_data)
+                        unicode_repr = data_bytes.decode('utf-8', errors='replace')
+                    except Exception:
+                        unicode_repr = "N/A"
+                    lines.append(f"Field {idx}: Length = {length}, AD Type = 0x{ad_type:02X} ({desc}), Data = {data}")
+                    lines.append(f"         Company ID       = {company_id}")
+                    lines.append(f"         Additional Data  = {additional_data}")
+                    lines.append(f"         Unicode          = {unicode_repr}")
+                else:
+                    try:
+                        data_bytes = bytes.fromhex(data)
+                        unicode_repr = data_bytes.decode('utf-8', errors='replace')
+                    except Exception:
+                        unicode_repr = "N/A"
+                    lines.append(f"Field {idx}: Length = {length}, AD Type = 0x{ad_type:02X} ({desc}), Data = {data}")
+                    lines.append(f"         Unicode          = {unicode_repr}")
+        else:
+            lines.append("No advertisement payload found.")
+        return "\n".join(lines)
+    elif display_mode == "gacp":
+        success, error_code, resp = get_gacp()
+        if success:
+            return "Extended Advertising Parameters:\n" + resp.strip()
+        else:
+            return "Failed to fetch GACP: " + str(error_code)
+    else:
+        return "Unknown display mode."
+
+def display_update_thread():
+    """
+    Thread function: continuously clear the screen and print the cached display text.
+    This thread reads from the global cache (updated by the main loop or keyboard thread).
+    """
+    global cached_display_text
+    while not stop_event.is_set():
+        clear_screen()
+        with display_lock:
+            text = cached_display_text
+        sys.stdout.write(text + "\n")
+        sys.stdout.flush()
+        time.sleep(1 / display_refresh_rate)
+
+
+
+
+
+
+
+
+
+
+
+def keyboard_input_thread():
+    """
+    Thread function to listen for keyboard input to switch display modes.
+    Press 'p' for payload display, 'g' for GACP (extended advertising parameters).
+    Uses msvcrt (for Windows) for non-blocking input.
+    """
+    global display_mode
+    try:
+        import msvcrt
+        while not stop_event.is_set():
+            if msvcrt.kbhit():
+                ch = msvcrt.getch().decode('utf-8').lower()
+                if ch == 'p':
+                    display_mode = "payload"
+                elif ch == 'g':
+                    display_mode = "gacp"
+            time.sleep(0.1)
+    except ImportError:
+        # For Unix-like systems, you might implement using sys.stdin and select
+        pass
+
+def main():
+    global cached_display_text, display_mode
+    # CLI input: ask for COM port number and device name (use defaults if blank)
+    com_port_number = input("Enter COM port number: ").strip()
+    device_name = input("Enter device name (default Hamed_Experiment): ").strip() or "Hamed_Experiment"
+
+    if not com_port_number:
+        print("Invalid COM port number. Exiting.")
+        return
+
+    com_port = "COM{}".format(com_port_number)
+
+    # Initialize the device
+    success, ev_device = init_device(com_port, device_name)
+    if not success:
+        print("Device initialization failed. Exiting.")
+        return
+
+    print("Device initialized. Starting experiment... (Press Ctrl+C to quit)")
+    print("Press 'p' to display payload details; press 'g' to display extended parameters (GACP).")
+
+    # Update payload initially.
+    new_payload_size = random.randint(50, 200)
+    set_smart_manufacturer_payload(new_payload_size)
+    # Update the display cache initially.
+    with display_lock:
+        cached_display_text = get_display_text()
+
+    # Start the display update thread.
+    disp_thread = threading.Thread(target=display_update_thread, daemon=True)
+    disp_thread.start()
+
+
+
+
+    # Start the keyboard input thread.
+    kb_thread = threading.Thread(target=keyboard_input_thread, daemon=True)
+    kb_thread.start()
+
+
+
+    # # Update device configuration immediately (for example, update payload every payload_update_interval seconds).
+    # new_payload_size = random.randint(32, 75)
+    # set_smart_manufacturer_payload(new_payload_size)
+
+
+
+
+    try:
+
+
+
+
+
+
+
+
+
+
+
+        while True:
+
+            # Update the cached display text after making changes.
+            with display_lock:
+                cached_display_text = get_display_text()
+            time.sleep(payload_update_interval)
+
+
+
+    except KeyboardInterrupt:
+        print("\nExperiment interrupted by user. Shutting down...")
+        stop_event.set()
+        disp_thread.join()
+        kb_thread.join()
+        close_device(ev_device)
+        print("Connection closed. End of experiment.")
+    finally:
+        pass
+
+if __name__ == "__main__":
+    main()

--- a/evkit_lib.py
+++ b/evkit_lib.py
@@ -2,10 +2,12 @@ from time import sleep
 import time
 import serial
 import re
+from enum import Enum
 
 # Global constant for the RX buffer size when reading responses.
-read_buffer_size = 256
-serial_port = 'COM3'
+read_buffer_size = 512
+serial_port = ''
+ev_kit = None
 
 
 # Note: You normally "Use SAD" for legacy advertisements (≤31 bytes).
@@ -30,8 +32,6 @@ Key Features:
 
 
 
-# Open the UART port to the BLE module (adjust COM port + baud as needed).
-ev_kit = serial.Serial(serial_port, baudrate=115200, timeout=1)
 
 
 
@@ -86,34 +86,44 @@ def get_firmware_version()->tuple:
 
 
 
-def set_device_name(device_name: str)->tuple:
+
+def set_device_name_extended(device_name: str) -> tuple:
     """
-    Sets the BLE device name by:
-      1) Stopping any current advertising (/AX).
-      2) Sending 'SDN,N=<device_name>'.
-      3) Optionally re-enabling advertisement (/CA).
+    Sets the BLE device name in extended advertising mode using the SERD command.
+    The payload format is:
+      - Length (hex): total bytes for type + device name
+      - Type (09): AD type for Complete Local Name
+      - Device Name: the UTF-8 encoded name in hex
 
-    Args:
-        device_name (str): The desired name (e.g. "MyDevice").
+    For example, for "HAMED_BLE_5":
+      - Name bytes: 11 bytes, so length = 0x0C (12 in decimal)
+      - Payload: "0C0948414D45445F424C455F35"
     """
-    # print(f"Setting device name to '{device_name}' in text mode...")
+    # Stop extended advertising before updating
+    # send_custom_command_text("/CAX")
 
-    # Stop all legacy advertisings
-    send_custom_command_text("/CAX")
-    send_custom_command_text("/AX")
+    # Convert the device name to bytes and then to a hex string.
+    name_bytes = device_name.encode('utf-8')
+    # Total length includes the 1-byte type (0x09)
+    total_length = len(name_bytes) + 1
+    # Format length as a 2-digit uppercase hex string
+    length_hex = f"{total_length:02X}"
+    # The AD type for Complete Local Name is 0x09
+    ad_type = "09"
+    # Convert the device name bytes to an uppercase hex string
+    name_hex = name_bytes.hex().upper()
 
-    # Send the "Set Device Name" command in text mode
-    command = f"SDN,N={device_name}"
-    success, error_code, response = send_custom_command_text(command)
+    # Build the full payload
+    payload = length_hex + ad_type + name_hex
 
-
-    # Re-enable advertising (if you want the new name to be shown
-    # in the local GATT Device Name or scan response).
-    send_custom_command_text("/CA")
-    send_custom_command_text("/A")
-
+    # Build and send the SERD command
+    serd_command = f"SERD,T=01,D={payload}"
+    success, error_code, response = send_custom_command_text(serd_command)
 
     return success, error_code, response
+
+
+
 
 
 
@@ -198,7 +208,7 @@ def reset_factory()->tuple:
 
 
 def extended_adv_config(P="01", M="01", T="09", H="00", I="00A0", C="07",
-                        L="00", O="0000", F="01", A="000000000000",
+                        L="00", O="0000", F="02", A="000000000000",
                         Y="00", E="00", S="00", D="00", N="0018")->tuple:
     """
     Configure EZ-Serial extended advertising parameters in text mode with SACP,
@@ -239,7 +249,7 @@ def extended_adv_config(P="01", M="01", T="09", H="00", I="00A0", C="07",
       - Then it sends the "SACP" command with your chosen params.
       - Finally, it calls "/CA" to start advertising again.
 
-      If your firmware is <1.3 (P=0001 in /QFV), extended adv won't work
+      If your firmware is <1.3 (P=0001 in /QFV), extended adv won't work,
       and you'll get errors like 0x020C.
     """
     # Stop any extended adv
@@ -293,82 +303,82 @@ def print_extended_parameters():
 
 
 
-def set_extended_adv_data(
-        payload_hex: str,
-        erase_or_append: int = 1,
-        adv_type: str = "08",
-        interval: str = "00A0",
-        discovery_mode: str = "00"
-)->tuple:
-    """
-    Configure extended advertising for custom data, then set the data using SEAD.
-
-    Steps in text mode:
-      1. Stop any extended advertising (/CAX).
-      2. Set SACP with P=1 (extended), T=adv_type, F=02 (use custom data),
-         plus interval, discovery, etc.
-      3. Use SEAD,T=<erase_or_append>,D=<payload_hex> to update the ext adv data.
-      4. Start advertising (/CA).
-
-    Args:
-        payload_hex (str): The hexadecimal string of your adv payload, e.g. '020106FF10FA021122334455'
-        erase_or_append (int):
-            - 0 => Erase existing extended data, then apply
-            - 1 => Append to existing buffer
-        adv_type (str):
-            - '08' => Non-connectable, non-scannable
-            - '09' => Non-connectable, scannable
-            - '06' => Connectable, undirected extended
-            etc.
-        interval (str):
-            BLE adv interval (in 0.625 ms units) in hex, e.g. '00A0' => 100 ms
-        discovery_mode (str):
-            '00' => Non-discoverable/broadcast
-            '01' => General discoverable
-    """
-    # 1) Stop any extended advertising
-    send_custom_command_text("/CAX")
-
-    # 2) SACP with:
-    #    - P=1 => Extended adv
-    #    - M=discovery_mode => '00' or '01'
-    #    - T=adv_type => '08', '09', ...
-    #    - I=interval => e.g. '00A0'
-    #    - F=02 => bit1 => "use custom data"
-    #
-    #    Other parameters kept minimal or zeroed out for simplicity.
-    sacp_cmd = (
-        f"SACP,P=01,"
-        f"M={discovery_mode},"
-        f"T={adv_type},"
-        f"H=00,"
-        f"I={interval},"
-        f"C=07,"
-        f"L=00,"
-        f"O=0000,"
-        f"F=02,"    # ** key bit: use custom data
-        f"A=000000000000,"
-        f"Y=00,"
-        f"E=00,"
-        f"S=00,"
-        f"D=00,"
-        f"N=0000"
-    )
-    send_custom_command_text(sacp_cmd)
-
-    # 3) Apply extended adv data with SEAD.
-    #    erase_or_append => 0 => T=00 => erase+overwrite,
-    #                      1 => T=01 => append
-    sead_cmd = f"SEAD,T=0{erase_or_append},D={payload_hex}"
-    success, error_code, response = send_custom_command_text(sead_cmd)
-
-   # 4) Start advertising
-    send_custom_command_text("/CA")
-
-
-    return success, error_code, response
-
-
+# def set_extended_adv_data(
+#         payload_hex: str,
+#         erase_or_append: int = 1,
+#         adv_type: str = "08",
+#         interval: str = "00A0",
+#         discovery_mode: str = "00"
+# )->tuple:
+#     """
+#     Configure extended advertising for custom data, then set the data using SEAD.
+#
+#     Steps in text mode:
+#       1. Stop any extended advertising (/CAX).
+#       2. Set SACP with P=1 (extended), T=adv_type, F=02 (use custom data),
+#          plus interval, discovery, etc.
+#       3. Use SEAD,T=<erase_or_append>,D=<payload_hex> to update the ext adv data.
+#       4. Start advertising (/CA).
+#
+#     Args:
+#         payload_hex (str): The hexadecimal string of your adv payload, e.g. '020106FF10FA021122334455'
+#         erase_or_append (int):
+#             - 0 => Erase existing extended data, then apply
+#             - 1 => Append to existing buffer
+#         adv_type (str):
+#             - '08' => Non-connectable, non-scannable
+#             - '09' => Non-connectable, scannable
+#             - '06' => Connectable, undirected extended
+#             etc.
+#         interval (str):
+#             BLE adv interval (in 0.625 ms units) in hex, e.g. '00A0' => 100 ms
+#         discovery_mode (str):
+#             '00' => Non-discoverable/broadcast
+#             '01' => General discoverable
+#     """
+#     # 1) Stop any extended advertising
+#     send_custom_command_text("/CAX")
+#
+#     # 2) SACP with:
+#     #    - P=1 => Extended adv
+#     #    - M=discovery_mode => '00' or '01'
+#     #    - T=adv_type => '08', '09', ...
+#     #    - I=interval => e.g. '00A0'
+#     #    - F=02 => bit1 => "use custom data"
+#     #
+#     #    Other parameters kept minimal or zeroed out for simplicity.
+#     sacp_cmd = (
+#         f"SACP,P=01,"
+#         f"M={discovery_mode},"
+#         f"T={adv_type},"
+#         f"H=00,"
+#         f"I={interval},"
+#         f"C=07,"
+#         f"L=00,"
+#         f"O=0000,"
+#         f"F=02,"    # ** key bit: use custom data
+#         f"A=000000000000,"
+#         f"Y=00,"
+#         f"E=00,"
+#         f"S=00,"
+#         f"D=00,"
+#         f"N=0000"
+#     )
+#     send_custom_command_text(sacp_cmd)
+#
+#     # 3) Apply extended adv data with SEAD.
+#     #    erase_or_append => 0 => T=00 => erase+overwrite,
+#     #                      1 => T=01 => append
+#     sead_cmd = f"SEAD,T=0{erase_or_append},D={payload_hex}"
+#     success, error_code, response = send_custom_command_text(sead_cmd)
+#
+#    # 4) Start advertising
+#     send_custom_command_text("/CA")
+#
+#
+#     return success, error_code, response
+#
+#
 
 
 
@@ -611,6 +621,11 @@ def get_error_description(response_code):
 
 
 
+
+
+
+
+
 def extract_error_code(response):
     """
     Extracts the success/error code from a response string.
@@ -645,6 +660,115 @@ def extract_error_code(response):
 
 
 
+class ADType(Enum):
+    FLAGS = 0x01  # Flags (Core Spec Supplement, Part A, Section 1.3)
+    INCOMPLETE_LIST_16_BIT_SERVICE_CLASS_UUIDS = 0x02  # Incomplete List of 16-bit Service Class UUIDs (Part A, Section 1.1)
+    COMPLETE_LIST_16_BIT_SERVICE_CLASS_UUIDS = 0x03    # Complete List of 16-bit Service Class UUIDs (Part A, Section 1.1)
+    INCOMPLETE_LIST_32_BIT_SERVICE_CLASS_UUIDS = 0x04    # Incomplete List of 32-bit Service Class UUIDs (Part A, Section 1.1)
+    COMPLETE_LIST_32_BIT_SERVICE_CLASS_UUIDS = 0x05      # Complete List of 32-bit Service Class UUIDs (Part A, Section 1.1)
+    INCOMPLETE_LIST_128_BIT_SERVICE_CLASS_UUIDS = 0x06   # Incomplete List of 128-bit Service Class UUIDs (Part A, Section 1.1)
+    COMPLETE_LIST_128_BIT_SERVICE_CLASS_UUIDS = 0x07     # Complete List of 128-bit Service Class UUIDs (Part A, Section 1.1)
+    SHORTENED_LOCAL_NAME = 0x08                          # Shortened Local Name (Part A, Section 1.2)
+    COMPLETE_LOCAL_NAME = 0x09                           # Complete Local Name (Part A, Section 1.2)
+    TX_POWER_LEVEL = 0x0A                                # Tx Power Level (Part A, Section 1.5)
+    CLASS_OF_DEVICE = 0x0D                               # Class of Device (Part A, Section 1.6)
+    SIMPLE_PAIRING_HASH_C192 = 0x0E                      # Simple Pairing Hash C-192 (Part A, Section 1.6)
+    SIMPLE_PAIRING_RANDOMIZER_R192 = 0x0F                # Simple Pairing Randomizer R-192 (Part A, Section 1.6)
+    DEVICE_ID = 0x10                                     # Device ID (Device ID Profile)
+    SM_TK_VALUE = 0x10                                   # Security Manager TK Value (Core Spec Supplement, Part A, Section 1.8) - alias for DEVICE_ID
+    SECURITY_MANAGER_OOB_FLAGS = 0x11                    # Security Manager Out of Band Flags (Part A, Section 1.7)
+    PERIPHERAL_CONNECTION_INTERVAL_RANGE = 0x12        # Peripheral Connection Interval Range (Part A, Section 1.9)
+    LIST_16_BIT_SERVICE_SOLICITATION_UUIDS = 0x14        # List of 16-bit Service Solicitation UUIDs (Part A, Section 1.10)
+    LIST_128_BIT_SERVICE_SOLICITATION_UUIDS = 0x15       # List of 128-bit Service Solicitation UUIDs (Part A, Section 1.10)
+    SERVICE_DATA_16_BIT_UUID = 0x16                      # Service Data – 16-bit UUID (Part A, Section 1.11)
+    PUBLIC_TARGET_ADDRESS = 0x17                         # Public Target Address (Part A, Section 1.13)
+    RANDOM_TARGET_ADDRESS = 0x18                         # Random Target Address (Part A, Section 1.14)
+    APPEARANCE = 0x19                                    # Appearance (Part A, Section 1.12)
+    ADVERTISING_INTERVAL = 0x1A                          # Advertising Interval (Part A, Section 1.15)
+    LE_BLUETOOTH_DEVICE_ADDRESS = 0x1B                   # LE Bluetooth Device Address (Part A, Section 1.16)
+    LE_ROLE = 0x1C                                     # LE Role (Part A, Section 1.17)
+    SIMPLE_PAIRING_HASH_C256 = 0x1D                      # Simple Pairing Hash C-256 (Part A, Section 1.6)
+    SIMPLE_PAIRING_RANDOMIZER_R256 = 0x1E                # Simple Pairing Randomizer R-256 (Part A, Section 1.6)
+    LIST_32_BIT_SERVICE_SOLICITATION_UUIDS = 0x1F        # List of 32-bit Service Solicitation UUIDs (Part A, Section 1.10)
+    SERVICE_DATA_32_BIT_UUID = 0x20                      # Service Data – 32-bit UUID (Part A, Section 1.11)
+    SERVICE_DATA_128_BIT_UUID = 0x21                     # Service Data – 128-bit UUID (Part A, Section 1.11)
+    LE_SECURE_CONNECTIONS_CONFIRMATION_VALUE = 0x22      # LE Secure Connections Confirmation Value (Part A, Section 1.6)
+    LE_SECURE_CONNECTIONS_RANDOM_VALUE = 0x23            # LE Secure Connections Random Value (Part A, Section 1.6)
+    URI = 0x24                                         # URI (Part A, Section 1.18)
+    INDOOR_POSITIONING = 0x25                            # Indoor Positioning (Indoor Positioning Service)
+    TRANSPORT_DISCOVERY_DATA = 0x26                      # Transport Discovery Data (Transport Discovery Service)
+    LE_SUPPORTED_FEATURES = 0x27                         # LE Supported Features (Part A, Section 1.19)
+    CHANNEL_MAP_UPDATE_INDICATION = 0x28                 # Channel Map Update Indication (Part A, Section 1.20)
+    PB_ADV = 0x29                                      # PB-ADV (Mesh Profile Specification, Section 5.2.1)
+    MESH_MESSAGE = 0x2A                                  # Mesh Message (Mesh Profile Specification, Section 3.3.1)
+    MESH_BEACON = 0x2B                                   # Mesh Beacon (Mesh Profile Specification, Section 3.9)
+    BIGINFO = 0x2C                                     # BIGInfo (Part A, Section 1.21)
+    BROADCAST_CODE = 0x2D                              # Broadcast_Code (Part A, Section 1.22)
+    RESOLVABLE_SET_IDENTIFIER = 0x2E                     # Resolvable Set Identifier (Coordinated Set Identification Profile v1.0 or later)
+    ADVERTISING_INTERVAL_LONG = 0x2F                     # Advertising Interval – long (Part A, Section 1.15)
+    BROADCAST_NAME = 0x30                                # Broadcast_Name (Public Broadcast Profile v1.0 or later)
+    ENCRYPTED_ADVERTISING_DATA = 0x31                    # Encrypted Advertising Data (Part A, Section 1.23)
+    PERIODIC_ADVERTISING_RESPONSE_TIMING_INFORMATION = 0x32  # Periodic Advertising Response Timing Information (Part A, Section 1.24)
+    ELECTRONIC_SHELF_LABEL = 0x34                        # Electronic Shelf Label (ESL Profile)
+    INFORMATION_3D = 0x3D                                # 3D Information Data (3D Synchronization Profile)
+    MANUFACTURER_SPECIFIC_DATA = 0xFF                    # Manufacturer Specific Data (Part A, Section 1.4)
+
+
+
+
+
+
+
+
+def set_custom_adv_payload(data: str, ad_type: ADType, append: bool = False) -> tuple:
+    """
+    Sets (or appends to) the extended advertisement payload using a SERD command.
+
+    For most AD types, the payload format is:
+        [Length][AD Type][Data]
+    For Manufacturer Specific Data (0xFF), the payload format is:
+        [Length][AD Type][Company ID][Data]
+    where the Company ID is 0x0131 (Infineon Semiconductor).
+
+    Args:
+        data (str): The advertisement data as a string. It will be UTF-8 encoded.
+        ad_type (ADType): The advertisement data type from the ADType enum.
+        append (bool): If False, the payload is first cleared using SERD with T=00.
+                       If True, the new data is appended (SERD with T=01).
+
+    Returns:
+        tuple: (success, error_code, response) from the SERD command.
+    """
+    # If not appending, first clear the existing payload.
+    if not append:
+        send_custom_command_text("SERD,T=00,D=")
+
+    # Encode the data into bytes.
+    data_bytes = data.encode('utf-8')
+
+    if ad_type == ADType.MANUFACTURER_SPECIFIC_DATA:
+        # For Manufacturer Specific Data, insert the company ID.
+        # Company ID for Infineon Semiconductor is 0x0131 (2 bytes).
+        company_id = "0900"
+        # Total length is 1 byte (AD type) + 2 bytes (company ID) + len(data_bytes)
+        total_length = len(data_bytes) + 3
+        length_hex = f"{total_length:02X}"
+        ad_type_hex = f"{ad_type.value:02X}"
+        data_hex = data_bytes.hex().upper()
+        # Build payload: length + AD type + company ID + data.
+        payload = length_hex + ad_type_hex + company_id + data_hex
+    else:
+        # For other AD types, total length is 1 (AD type) + len(data_bytes)
+        total_length = len(data_bytes) + 1
+        length_hex = f"{total_length:02X}"
+        ad_type_hex = f"{ad_type.value:02X}"
+        data_hex = data_bytes.hex().upper()
+        # Build payload: length + AD type + data.
+        payload = length_hex + ad_type_hex + data_hex
+
+    # Build and send the SERD command to append the payload (T=01).
+    serd_cmd = f"SERD,T=01,D={payload}"
+    return send_custom_command_text(serd_cmd)
 
 
 
@@ -658,71 +782,431 @@ def extract_error_code(response):
 
 
 
-# Main usage example
-try:
-    # Factory reset the module so we start fresh
-    # reset_factory()
+
+
+
+
+
+def get_gerd() -> tuple:
+    """
+    Sends the GERD command to retrieve the current advertising payload.
+
+    Returns:
+        tuple: (success, error_code, response) from the BLE module.
+               The response typically contains the raw hex payload in the form "D=<payload>".
+    """
+    return send_custom_command_text("GERD")
+
+
+
+
+
+
+
+
+
+
+def get_gacp() -> tuple:
+    """
+    Sends the GACP command to retrieve the current extended advertising parameters.
+
+    Returns:
+        tuple: (success, error_code, response) from the BLE module.
+               The response typically shows the extended advertising configuration.
+    """
+    return send_custom_command_text("GACP")
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+def get_adv_payload_details() -> tuple:
+    """
+    Retrieves the current extended advertisement payload using the GERD command and
+    parses it into its component fields.
+
+    The expected format of the payload is a series of AD structures:
+      [Length][AD Type][Data]
+
+    For Manufacturer Specific Data (AD Type 0xFF), the Data field is:
+      [Company ID (2 bytes)][Additional Data]
+
+    Returns:
+        tuple:
+          - raw_payload (str): The entire payload as a hex string (e.g., "0201060C0948414D45445F424C455F35")
+          - fields (list): A list of tuples, each representing one field.
+            Each tuple is of the form:
+              (field_length (int), ad_type (int), field_data (str))
+            where field_data is a hex string representing the AD data.
+
+    If no payload is found or an error occurs, returns ("", []).
+    """
+    # Issue the GERD command to get the advertisement payload.
+    success, error_code, response = send_custom_command_text("GERD")
+    if not success:
+        # In case of failure, return empty values.
+        return ("", [])
+
+    # The response is expected to contain "D=<payload>".
+    m = re.search(r"D=([0-9A-Fa-f]+)", response)
+    if not m:
+        # No payload data found.
+        return ("", [])
+
+    raw_payload = m.group(1)
+    fields = []
+    i = 0
+    # Parse the raw hex payload.
+    while i < len(raw_payload):
+        # Ensure there are at least 2 hex characters for the length.
+        if i + 2 > len(raw_payload):
+            break
+        # The first byte is the length (in hex).
+        field_length = int(raw_payload[i:i+2], 16)
+        i += 2
+
+        # A length of 0 indicates no further fields.
+        if field_length == 0:
+            break
+
+        # Next 2 hex digits represent the AD Type.
+        if i + 2 > len(raw_payload):
+            break
+        ad_type = int(raw_payload[i:i+2], 16)
+        i += 2
+
+        # The remaining (field_length - 1) bytes are the data.
+        data_byte_count = field_length - 1  # number of bytes
+        data_hex_length = data_byte_count * 2  # each byte is 2 hex characters
+
+        if i + data_hex_length > len(raw_payload):
+            # If the payload is truncated, take whatever is left.
+            field_data = raw_payload[i:]
+            i = len(raw_payload)
+        else:
+            field_data = raw_payload[i:i + data_hex_length]
+            i += data_hex_length
+
+        fields.append((field_length, ad_type, field_data))
+
+    return raw_payload, fields
+
+
+
+
+
+
+
+
+
+
+def print_adv_payload_details():
+    """
+    Retrieves and prints the current extended advertisement payload.
+
+    It calls get_adv_payload_details() to get:
+      - The raw payload (a hex string)
+      - A list of fields, each as a tuple: (field_length, ad_type, field_data)
+
+    It then prints:
+      - The raw payload along with its total size in bytes.
+      - For each field: field number, Length, AD Type (in hex) with its enum name,
+        and the raw data in hex along with its ASCII and Unicode representations.
+
+    For Manufacturer Specific Data (AD Type 0xFF), the field data is assumed to be in the format:
+      [Company ID (2 bytes)][Additional Data]
+    In that case, only the Additional Data portion (skipping the first 4 hex characters) is decoded.
+    """
+    raw_payload, fields = get_adv_payload_details()
+
+    if raw_payload:
+        # Calculate total raw payload size in bytes (each two hex characters represent one byte)
+        payload_size = len(raw_payload) // 2
+        print("\nRaw Payload:", raw_payload)
+        print(f"Total Raw Payload Size: {payload_size} bytes\n")
+
+        for idx, (length, ad_type, data) in enumerate(fields, start=1):
+            # Lookup AD type description using the ADType enum.
+            try:
+                ad_enum = ADType(ad_type)
+                desc = ad_enum.name.replace("_", " ").title()
+            except ValueError:
+                desc = "Unknown"
+
+            # Check if the field is Manufacturer Specific Data.
+            if ad_type == ADType.MANUFACTURER_SPECIFIC_DATA.value:
+                # For Manufacturer Specific Data, the first 2 bytes (4 hex characters) are the Company ID.
+                company_id = data[:4]
+                additional_data = data[4:]
+                # Decode only the additional data portion.
+                try:
+                    data_bytes = bytes.fromhex(additional_data)
+                    # ascii_repr = data_bytes.decode('ascii', errors='replace')
+                    unicode_repr = data_bytes.decode('utf-8', errors='replace')
+                except Exception:
+                    ascii_repr = "N/A"
+                    unicode_repr = "N/A"
+                print(f"Field {idx}: Length = {length}, AD Type = 0x{ad_type:02X} ({desc}), Data = {data}")
+                print(f"         Company ID       = {company_id}")
+                print(f"         Additional Data  = {additional_data}")
+                # print(f"         ASCII            = {ascii_repr}")
+                print(f"         Unicode          = {unicode_repr}")
+            else:
+                # For other AD types, decode the entire data string.
+                try:
+                    data_bytes = bytes.fromhex(data)
+                    # ascii_repr = data_bytes.decode('ascii', errors='replace')
+                    unicode_repr = data_bytes.decode('utf-8', errors='replace')
+                except Exception:
+                    ascii_repr = "N/A"
+                    unicode_repr = "N/A"
+                print(f"Field {idx}: Length = {length}, AD Type = 0x{ad_type:02X} ({desc}), Data = {data}")
+                # print(f"         ASCII            = {ascii_repr}")
+                print(f"         Unicode          = {unicode_repr}")
+    else:
+        print("No advertisement payload found.")
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+def set_smart_manufacturer_payload(total_payload_bytes: int) -> tuple:
+    """
+    Creates and sends a manufacturer-specific advertising payload based on the desired total byte size.
+
+    For Manufacturer Specific Data (AD Type 0xFF), the payload format is:
+      [Length][AD Type][Company ID][Additional Data]
+
+    This function uses a fixed Company ID of "0900". The Additional Data length is:
+         total_payload_bytes - 3
+    (1 byte for AD type + 2 bytes for Company ID).
+
+    It uses an excerpt inspired by Thomas Paine's "Common Sense" as the base message:
+         "In these troubled times, the words of Thomas Paine remind us that government
+          exists not to oppress but to secure the rights of all men. Let us unite for liberty."
+    This text is then cut (or padded) so that its UTF-8 encoding exactly fits the available space.
+
+    Args:
+        total_payload_bytes (int): Total size (in bytes) for the manufacturer-specific data field.
+                                   This includes 1 byte for AD type, 2 bytes for Company ID, and the remainder for additional data.
+
+    Returns:
+        tuple: (success, error_code, response) from sending the SERD command.
+    """
+    if total_payload_bytes < 3:
+        return (False, 0xEEEE, "Total payload size must be at least 3 bytes.")
+
+    # Calculate available bytes for additional data.
+    additional_data_length = total_payload_bytes - 3
+
+    # A famous excerpt inspired by Thomas Paine's "Common Sense"
+    base_message = (
+        "Fellow citizens, in these hours of great challenge, let us recall the profound truths set forth by Thomas Paine "
+        "in his work 'Common Sense'. He urged us to question the legitimacy of inherited tyranny and to embrace the principles "
+        "of liberty, equality, and fraternity. In his passionate call for independence, Paine declared that government is a necessary "
+        "evil, designed by man for the protection of his natural rights, and not a divine institution to be blindly followed. "
+        "He challenged us to examine the foundations of power and to reject any system that does not guarantee the dignity and freedom "
+        "of the individual. His words continue to resonate in the hearts of those who seek a just and rational society. Let us be inspired "
+        "by his vision, daring to construct a future where every man and woman is free to pursue happiness and where government serves "
+        "only to safeguard our inalienable rights. May this message remind us that the spirit of revolution and the quest for justice are eternal, "
+        "and that each of us has a role to play in the ongoing struggle for a better world."
+    )
+
+    # Adjust the message so that its UTF-8 encoded byte length exactly matches additional_data_length.
+    # For simplicity, we assume each character is one byte (i.e. the text is plain ASCII).
+    # (If multi-byte characters are possible, further logic may be required.)
+    if len(base_message) < additional_data_length:
+        additional_data = base_message + " " * (additional_data_length - len(base_message))
+    else:
+        additional_data = base_message[:additional_data_length]
+
+    # Encode the additional data to bytes.
+    data_bytes = additional_data.encode('utf-8')
+
+    # Total length (in bytes) is: 1 (for AD type) + 2 (for Company ID) + len(data_bytes)
+    total_length = len(data_bytes) + 3
+    length_hex = f"{total_length:02X}"
+    ad_type_hex = f"{ADType.MANUFACTURER_SPECIFIC_DATA.value:02X}"
+    # Use the fixed company ID "0900"
+    company_id = "0900"
+    data_hex = data_bytes.hex().upper()
+
+    # Build the payload: [Length][AD Type][Company ID][Additional Data]
+    payload = length_hex + ad_type_hex + company_id + data_hex
+
+    # Build and send the SERD command (T=01 means append the payload)
+    serd_cmd = f"SERD,T=01,D={payload}"
+    return send_custom_command_text(serd_cmd)
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+def init_device(serial_port_par:str, device_name:str) -> tuple:
+    """
+    Initializes the device by rebooting it, configuring the extended advertising parameters,
+    and erasing any existing advertisement payload. This function does not close the COM port,
+    leaving the device ready for a new payload.
+
+    Returns:
+        bool: True if all steps succeeded, False otherwise.
+    """
+    # Reboot the device
+
+
+    global ev_kit
+    # Open the UART port to the BLE module (adjust COM port + baud as needed).
+    ev_kit = serial.Serial(serial_port_par, baudrate=115200, timeout=1)
+
+
 
     success, error_code, response = reboot_device()
     if success:
         print("Rebooted device successfully")
     else:
-        print("Failed to reboot device")
+        print("Failed to reboot device:", get_error_description(error_code))
+        return False, ev_kit
 
+    # Wait a short period for the device to fully reboot
+    sleep(1)
 
-    success, error_code, response = get_firmware_version()
-    if success:
-        print(">>> Firmware version:", response)
-    else:
-        print(">>> Failed to get firmware version:", get_error_description(error_code))
-
-
-
-    success, error_code, response = set_device_name("HAMED_BLE")
-    if success:
-        print(">>> Device name set successfully")
-    else:
-        print(">>> Failed to set device name:", get_error_description(error_code))
-
-
-
-    # Example: configure extended adv with default arguments
-
+    # Configure extended advertisement parameters
     success, error_code, response = extended_adv_config()
     if success:
-        print(">>> Extended advertisement parameters configured successfully")
+        print("Extended advertisement parameters configured successfully")
     else:
-        print(">>> Failed to configure extended advertisement parameters:", get_error_description(error_code))
+        print("Failed to configure extended advertisement parameters:", get_error_description(error_code))
+        return False, ev_kit
+
+    # Erase any existing advertisement payload
+    success, error_code, response = send_custom_command_text("SERD,T=00,D=")
+    if success:
+        print("Cleared existing advertisement payload")
+    else:
+        print("Failed to clear advertisement payload:", get_error_description(error_code))
+        return False, ev_kit
+
+
+
+    success, error_code, response = set_device_name_extended(device_name)
+    if success:
+        print("Extended device name set successfully")
+    else:
+        print("Failed to set extended device name:", get_error_description(error_code))
+        return False, ev_kit
 
 
 
 
 
-    #Doesn't work due to API protocol ver being 1.1 not higher
-    # set_extended_adv_data(
-    #     payload_hex="020106FF10FA021122334455",  # your custom bytes
-    #     erase_or_append=0,
-    #     adv_type="08",        # non-scannable
-    #     interval="00A0",      # 100 ms
-    #     discovery_mode="00"   # broadcast-only
-    # )
-
-    # Print out what the module thinks is set for adv parameters
-    print_extended_parameters()
-
-
-    # send_custom_command_text("GEAD")
-    # Potentially we could then do SEAD if the firmware truly is 1.3+,
-    # but if P=0001 we know it's old so it'd fail with 0x020C.
-
-    
-    # send_custom_command_text("SEAD,T=01,D=020106FF10FA021122334455")
-    # send_custom_command_text("GEAD")
+    return True, ev_kit
 
 
 
 
-finally:
+
+
+
+
+
+
+def close_device(ev_kit:serial.Serial):
     # Make sure we close the serial port on exit
     ev_kit.close()
     print("Connection closed.")
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+


### PR DESCRIPTION
This pull request introduces two major updates:

New High-Level Experiment Script (ble_stat_experiment.py):

Dynamic BLE Experiment: Implements a responsive, statistical experiment loop for BLE advertising that updates payload configurations on the fly.
Parallel Display Update: Uses a dedicated display update thread to refresh terminal output smoothly without blocking the main loop.
Keyboard Interactivity: Includes a keyboard input thread that allows switching between displaying payload details and extended advertising parameters (via GACP), enabling real-time control over display content.
Responsive Configuration: The main loop remains responsive for immediate device configuration changes, paving the way for future enhancements like additional keyboard commands.
Enhancements to evkit_lib.py:

Helper Functions: Added new functions (get_gerd(), get_gacp(), get_adv_payload_details(), and print_adv_payload_details()) for streamlined retrieval and formatting of advertising data.
Smart Manufacturer Payload: Improved set_smart_manufacturer_payload() to generate manufacturer-specific payloads using an excerpt inspired by Thomas Paine’s "Common Sense", with appropriate truncation or padding based on the specified byte size.
Improved Initialization & Configuration: Refined device initialization (init_device()) and extended advertising configuration (extended_adv_config()) routines to ensure reliable operation.
Error Handling: Enhanced error extraction and description functionality via extract_error_code() and get_error_description().