### PR TITLE
feat: Prepare system for experiment design with dynamic extended adv payload

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,148 @@
-# chip-controller
+# BLE Stat Experiment
+
+This project demonstrates an experiment using Infineon BLE modules with EZ-Serial firmware. The experiment is implemented in Python and shows how to retrieve, update, and display BLE advertisement parameters, including both legacy payload details and extended advertising (GACP) parameters.
+
+---
+
+## Overview
+
+- **Real-Time Display:** Continuously updating display of advertising data.
+- **Payload Customization:** Random updates to the manufacturer-specific payload.
+- **Extended Advertising Parameters:** Ability to switch the display between raw payload details and extended advertising (GACP) parameters.
+- **Interactive Control:** Keyboard inputs to switch display modes and adjust the advertising interval.
+
+Designed for rapid prototyping with Infineon’s CYW20822 module, this project uses EZ-Serial firmware (see [Infineon EZ-Serial firmware platform user guide for CYW20822 module](&#8203;:contentReference[oaicite:0]{index=0})) for detailed command and configuration information.
+
+---
+
+## Project Files
+
+- **ble_stat_experiment.py**  
+  The main Python script that runs the experiment. It updates the BLE advertising payload at regular intervals, reads advertising details, and displays them in real time.
+
+- **evkit_lib.py**  
+  A library of functions that wrap API commands to interact with the BLE module (e.g., setting device name, starting/stopping advertising, querying firmware version).
+
+- **Infineon-EZ-Serial_firmware_platform_user_guide_for_CYW20822_module-UserManual-v02_00-EN.pdf**  
+  The official user guide for the EZ-Serial firmware platform, containing detailed hardware, API, and command usage information.
+
+- **Assigned_Numbers.pdf**  
+  A document listing Bluetooth® assigned numbers and identifiers for reference when working with BLE protocols.
+
+- **7 API protocol reference.pdf**  
+  A comprehensive reference covering the API protocol used by the EZ-Serial firmware, including text and binary modes, data types, command structure, and error codes.
+
+---
+
+## Prerequisites
+
+- **Hardware/Software Requirements:**
+    - A computer with Python 3 installed.
+    - The `pyserial` package for serial communication.  
+      Install via:
+      ```
+      pip install pyserial
+      ```
+    - *(Optional for Windows)* The `colorama` package for proper terminal clearing.  
+      Install via:
+      ```
+      pip install colorama
+      ```
+    - A compatible Infineon BLE module (e.g., CYW20822 module with EZ-Serial firmware) connected via a serial interface.
+    - A USB-to-serial adapter if not using the built-in evaluation kit.
+
+---
+
+## Setup
+
+1. **Connect the Device:**
+    - Ensure your Infineon BLE module or evaluation kit (e.g., CYW920822M2P4XXI040-EVK) is properly connected to your computer.
+    - Identify the COM port assigned to the device.
+
+2. **Configure the Script:**
+    - Open `ble_stat_experiment.py` in your favorite code editor.
+    - Review the experiment parameters at the top of the file:
+        - `payload_update_interval`: Frequency (in seconds) for payload updates.
+        - `display_refresh_rate`: Display refresh rate (in Hz).
+        - `adv_interval_ms`: Initial advertising interval in milliseconds.
+        - `adv_interval_jump_amount`: Step amount (in ms) for increasing or decreasing the advertising interval via keyboard input.
+
+---
+
+## Running the Experiment
+
+1. **Launch the Script:**
+    - Execute the following command in your terminal:
+      ```
+      python ble_stat_experiment.py
+      ```
+
+2. **Provide Input:**
+    - Enter the COM port number when prompted (e.g., if the device is on COM3, enter `3`).
+    - Enter a device name or press Enter to use the default (`Hamed_Experiment`).
+
+3. **Experiment Behavior:**
+    - After initialization, the device starts broadcasting BLE advertisements with a random manufacturer-specific payload.
+    - The display updates in real time with either:
+        - **Payload Details:** Raw advertisement payload broken down into fields.
+        - **GACP Details:** Extended advertising parameters (if supported by the firmware).
+    - **Keyboard Commands:**
+        - **p:** Switch to payload details display.
+        - **g:** Switch to GACP (extended advertising parameters) display.
+        - **s:** Increase the advertising interval (lowers transmission rate).
+        - **f:** Decrease the advertising interval (increases transmission rate).
+    - Press **Ctrl+C** to gracefully stop the experiment.
+
+---
+
+## Technical Details
+
+### Advertising Parameters
+
+- **Legacy & Extended Advertising:**  
+  Supports both legacy advertising and extended advertising configurations.
+
+- **Extended Advertising Parameters Include:**
+    - **Advertising Mode (P):**
+        - `0` = Legacy (factory default)
+        - `1` = Extended
+        - `2` = Periodic
+    - **Discovery Mode (M):**
+        - `0` = Non-discoverable/broadcast-only
+        - `1` = General discovery (factory default)
+    - Additional parameters such as Advertising Type (T), Primary PHY (H), Interval (I), etc., are configured via EZ-Serial API commands (see `extended_adv_config` in `evkit_lib.py`).
+
+### API Protocol
+
+- **Communication:**  
+  Uses a set of API commands (in both text and binary formats) to interact with the BLE module.
+- **Reference Documentation:**  
+  Detailed information on API commands, responses, and error codes is available in:
+    - [Infineon EZ-Serial firmware platform user guide for CYW20822 module](&#8203;:contentReference[oaicite:1]{index=1})
+    - [7 API protocol reference.pdf](&#8203;:contentReference[oaicite:2]{index=2})
+
+### Error Handling
+
+- Functions in `evkit_lib.py` return a tuple in the format `(success, error_code, response)`.
+- Detailed error codes and their meanings are documented in the API protocol reference.
+
+---
+
+## Troubleshooting
+
+- **No Data Displayed:**  
+  Verify that the correct COM port is entered and that the BLE module is powered on.
+
+- **Communication Issues:**  
+  Check your serial connection and ensure the serial settings (baud rate, etc.) match the device's factory defaults.
+
+- **Advertising Issues:**  
+  If extended advertising commands return errors, ensure your module’s firmware is version 1.3 or newer.
+
+---
+
+## License
+
+This project is provided as-is without any warranties. Refer to the related Infineon and Bluetooth SIG documents for legal and licensing information regarding EZ-Serial firmware and Bluetooth specifications.
+
+---

--- a/ble_stat_experiment.py
+++ b/ble_stat_experiment.py
@@ -11,12 +11,24 @@ from evkit_lib import (
     get_gacp,
     print_adv_payload_details,  # legacy payload display, not used directly now
     close_device,
-    ADType
+    ADType, get_gacp_details, set_adv_interval
 )
 
+
+
+
 # Experiment parameters
-payload_update_interval = 5  # seconds between payload updates
-display_refresh_rate = 60    # display refresh rate in Hz
+payload_update_interval = 6  # seconds between payload updates
+display_refresh_rate = 120    # display refresh rate in Hz
+adv_interval_ms = 20  # starting value (must be between 20 and 10240)
+adv_interval_jump_amount = 500 #the ms amount of up or down by keyboard input
+
+
+
+
+
+
+
 
 # Global cache for display text and its lock
 display_lock = threading.Lock()
@@ -44,6 +56,237 @@ def clear_screen():
         else:
             print("\n" * 100)
 
+
+
+
+
+
+
+
+
+def format_interval(hex_value: str) -> str:
+    try:
+        val = int(hex_value, 16)
+        ms = val * 0.625  # Each unit is 0.625 ms
+        return f"{hex_value} (0x{val:04X}) => {ms:.2f} ms"
+    except Exception:
+        return hex_value
+
+
+
+
+
+
+
+def format_channels(hex_value: str) -> str:
+    try:
+        val = int(hex_value, 16)
+        channels = []
+        if val & 0x1:
+            channels.append("Channel 37")
+        if val & 0x2:
+            channels.append("Channel 38")
+        if val & 0x4:
+            channels.append("Channel 39")
+        if channels:
+            return f"{hex_value} -> " + ", ".join(channels)
+        else:
+            return hex_value
+    except Exception:
+        return hex_value
+
+
+
+
+
+
+
+
+
+def format_flags(hex_value: str) -> str:
+    try:
+        val = int(hex_value, 16)
+        flags = []
+        if val & 0x1:
+            flags.append("Auto-start on boot/disconnection")
+        if val & 0x2:
+            flags.append("Use custom adv/scan response data")
+        if flags:
+            return f"{hex_value} -> " + ", ".join(flags)
+        else:
+            return f"{hex_value} (No flags set, factory default)"
+    except Exception:
+        return hex_value
+
+
+
+
+
+
+def format_mac(hex_value: str) -> str:
+    if len(hex_value) == 12:
+        return ":".join(hex_value[i:i+2] for i in range(0, 12, 2))
+    return hex_value
+
+
+
+
+
+
+
+
+
+def get_gacp_display_text() -> str:
+    """
+    Retrieves the extended advertising parameters using get_gacp_details()
+    and returns a formatted multi-line string with descriptive text for each parameter.
+
+    Expected parameters (keys) include:
+      P: Advertisement mode
+         • 0 = Legacy (factory default)
+         • 1 = Extended
+         • 2 = Periodic
+      M: Discovery mode
+         • 0 = Non-discoverable/broadcast-only
+         • 1 = General discovery (factory default)
+      T: Advertisement type
+         • 0x00 = Legacy: Connectable, undirected (factory default)
+         • 0x01 = Legacy: Connectable, directed
+         • 0x02 = Legacy: Scannable, undirected
+         • 0x03 = Legacy: Non-connectable, undirected
+         • 0x04 = Periodic: Undirected
+         • 0x05 = Periodic: Directed
+         • 0x06 = Extended: Undirected connectable
+         • 0x07 = Extended: Directed connectable
+         • 0x08 = Extended: Non-connectable, non-scannable
+         • 0x09 = Extended: Non-connectable, scannable
+         • 0x0A = Extended: Non-connectable anonymous directed
+      H: Primary PHY
+         • 0 = 1M (factory default)
+         • 1 = 2M
+         • 2 = Coded
+      I: Advertisement interval (625 μs units)
+      C: Advertisement channels bitmask
+      L: Filter policy
+         • 0 = Scan and connect from any (factory default)
+         • 1 = Scan whitelist-only, connect any
+         • 2 = Scan any, connect whitelist-only
+         • 3 = Scan and connect whitelist-only
+      O: Advertisement timeout (seconds)
+      F: Advertisement behavior flags bitmask
+         • Bit 0 = Auto-start on boot/disconnection
+         • Bit 1 = Use custom adv/scan response data
+      A: Directed advertisement address (MAC)
+      Y: Directed address type:
+         • 0 = BLE_ADDR_PUBLIC
+         • 1 = BLE_ADDR_RANDOM
+      E: Secondary PHY (same mapping as H)
+      S: Secondary max skip (integer)
+      D: Secondary SID (0x00–0x0F)
+      N: Periodic interval (1.25 ms units)
+
+    Returns:
+        A formatted string listing each parameter with descriptive values.
+    """
+    success, error_code, fields, raw_response = get_gacp_details()
+    if not success:
+        return "Failed to fetch GACP details: " + str(error_code)
+    if not fields:
+        return "No extended advertising parameters found."
+
+    lines = ["Extended Advertising Parameters:"]
+    for key, value in fields:
+        try:
+            int_val = int(value, 16)
+        except Exception:
+            int_val = None
+
+        if key == "P":
+            adv_mode = {0: "Legacy (factory default)", 1: "Extended", 2: "Periodic"}.get(int_val, value) if int_val is not None else value
+            lines.append(f"P (Adv_mode) = {value} -> {adv_mode}")
+        elif key == "M":
+            disc_mode = {0: "Non-discoverable/broadcast-only", 1: "General discovery (factory default)"}.get(int_val, value) if int_val is not None else value
+            lines.append(f"M (Disc_mode) = {value} -> {disc_mode}")
+        elif key == "T":
+            adv_type = {
+                0x00: "Legacy: Connectable, undirected (factory default)",
+                0x01: "Legacy: Connectable, directed",
+                0x02: "Legacy: Scannable, undirected",
+                0x03: "Legacy: Non-connectable, undirected",
+                0x04: "Periodic: Undirected",
+                0x05: "Periodic: Directed",
+                0x06: "Extended: Undirected connectable",
+                0x07: "Extended: Directed connectable",
+                0x08: "Extended: Non-connectable, non-scannable",
+                0x09: "Extended: Non-connectable, scannable",
+                0x0A: "Extended: Non-connectable anonymous directed"
+            }.get(int_val, value) if int_val is not None else value
+            lines.append(f"T (Type) = {value} -> {adv_type}")
+        elif key == "H":
+            primary_phy = {0: "1M (factory default)", 1: "2M", 2: "Coded"}.get(int_val, value) if int_val is not None else value
+            lines.append(f"H (Primary_phy) = {value} -> {primary_phy}")
+        elif key == "I":
+            try:
+                interval_units = int(value, 16)
+                interval_ms = interval_units * 0.625
+                lines.append(f"I (Interval) = {value} -> {interval_ms:.2f} ms = {interval_ms/1000:.2f} s")
+            except Exception:
+                lines.append(f"I (Interval) = {value}")
+        elif key == "C":
+            lines.append(f"C (Channels) = {format_channels(value)}")
+        elif key == "L":
+            filter_policy = {0: "Scan and connect from any (factory default)", 1: "Scan whitelist-only, connect any",
+                             2: "Scan any, connect whitelist-only", 3: "Scan and connect whitelist-only"}.get(int_val, value) if int_val is not None else value
+            lines.append(f"L (Filter) = {value} -> {filter_policy}")
+        elif key == "O":
+            try:
+                timeout_sec = int(value, 16)
+                lines.append(f"O (Timeout) = {value} -> {timeout_sec} seconds")
+            except Exception:
+                lines.append(f"O (Timeout) = {value}")
+        elif key == "F":
+            lines.append(f"F (Flags) = {format_flags(value)}")
+        elif key == "A":
+            lines.append(f"A (Directed Adv Address) = {value} -> {format_mac(value)}")
+        elif key == "Y":
+            direct_type = {0: "BLE_ADDR_PUBLIC", 1: "BLE_ADDR_RANDOM"}.get(int_val, value) if int_val is not None else value
+            lines.append(f"Y (Directed Addr Type) = {value} -> {direct_type}")
+        elif key == "E":
+            secondary_phy = {0: "1M (factory default)", 1: "2M", 2: "Coded"}.get(int_val, value) if int_val is not None else value
+            lines.append(f"E (Secondary_phy) = {value} -> {secondary_phy}")
+        elif key == "S":
+            try:
+                max_skip = int(value, 16)
+                lines.append(f"S (Secondary_max_skip) = {value} -> {max_skip}")
+            except Exception:
+                lines.append(f"S (Secondary_max_skip) = {value}")
+        elif key == "D":
+            try:
+                sid = int(value, 16)
+                lines.append(f"D (Secondary_SID) = {value} -> {sid}")
+            except Exception:
+                lines.append(f"D (Secondary_SID) = {value}")
+        elif key == "N":
+            try:
+                periodic_units = int(value, 16)
+                periodic_ms = periodic_units * 1.25
+                lines.append(f"N (Periodic_interval) = {value} -> {periodic_ms:.2f} ms")
+            except Exception:
+                lines.append(f"N (Periodic_interval) = {value}")
+        else:
+            lines.append(f"{key} = {value}")
+
+    return "\n".join(lines)
+
+
+
+
+
+
+
+
+
+
 def get_display_text() -> str:
     """
     Retrieves and formats the current advertising payload details
@@ -51,7 +294,10 @@ def get_display_text() -> str:
     into a multi-line string.
     """
     global display_mode
+
+
     if display_mode == "payload":
+
         raw_payload, fields = get_adv_payload_details()
         lines = []
         if raw_payload:
@@ -87,14 +333,29 @@ def get_display_text() -> str:
         else:
             lines.append("No advertisement payload found.")
         return "\n".join(lines)
+
+
+
+
     elif display_mode == "gacp":
-        success, error_code, resp = get_gacp()
-        if success:
-            return "Extended Advertising Parameters:\n" + resp.strip()
-        else:
-            return "Failed to fetch GACP: " + str(error_code)
+
+        return get_gacp_display_text()
+
+
+
     else:
         return "Unknown display mode."
+
+
+
+
+
+
+
+
+
+
+
 
 def display_update_thread():
     """
@@ -120,13 +381,23 @@ def display_update_thread():
 
 
 
+
+
+
+
+
+
+
 def keyboard_input_thread():
     """
-    Thread function to listen for keyboard input to switch display modes.
-    Press 'p' for payload display, 'g' for GACP (extended advertising parameters).
+    Thread function to listen for keyboard input.
+    - 'p': switch to payload display
+    - 'g': switch to GACP display
+    - '+': increase advertising interval (thus lowering the transmission rate)
+    - '-': decrease advertising interval (thus increasing the transmission rate)
     Uses msvcrt (for Windows) for non-blocking input.
     """
-    global display_mode
+    global display_mode, adv_interval_ms
     try:
         import msvcrt
         while not stop_event.is_set():
@@ -136,13 +407,45 @@ def keyboard_input_thread():
                     display_mode = "payload"
                 elif ch == 'g':
                     display_mode = "gacp"
+                elif ch == 's':
+                    # Increase the advertising interval (lower transmission frequency)
+                    adv_interval_ms += adv_interval_jump_amount  # adjust increment as needed
+                    if adv_interval_ms > 10240:
+                        adv_interval_ms = 10240  # enforce maximum limit
+                    set_adv_interval(adv_interval_ms)
+                    print(f"Increased advertising interval to {adv_interval_ms} ms")
+                elif ch == 'f':
+                    # Decrease the advertising interval (increase transmission frequency)
+                    # Ensure that the interval does not go below the minimum allowed (20 ms)
+                    adv_interval_ms = max(20, adv_interval_ms - adv_interval_jump_amount)
+                    set_adv_interval(adv_interval_ms)
+                    print(f"Decreased advertising interval to {adv_interval_ms} ms")
             time.sleep(0.1)
     except ImportError:
         # For Unix-like systems, you might implement using sys.stdin and select
         pass
 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 def main():
-    global cached_display_text, display_mode
+    global cached_display_text, display_mode, adv_interval_ms
     # CLI input: ask for COM port number and device name (use defaults if blank)
     com_port_number = input("Enter COM port number: ").strip()
     device_name = input("Enter device name (default Hamed_Experiment): ").strip() or "Hamed_Experiment"
@@ -165,6 +468,11 @@ def main():
     # Update payload initially.
     new_payload_size = random.randint(50, 200)
     set_smart_manufacturer_payload(new_payload_size)
+    set_adv_interval(adv_interval_ms)
+
+
+
+
     # Update the display cache initially.
     with display_lock:
         cached_display_text = get_display_text()
@@ -185,8 +493,6 @@ def main():
     # # Update device configuration immediately (for example, update payload every payload_update_interval seconds).
     # new_payload_size = random.randint(32, 75)
     # set_smart_manufacturer_payload(new_payload_size)
-
-
 
 
     try:


### PR DESCRIPTION
Summary:
This PR integrates changes to prepare the system for experimental design. The module now reboots with a customized advertising payload and device name using non-connectable, non-scannable broadcast mode. The extended advertising payload is set using SEAD commands.

Key Changes:

Device Initialization:
The device reboots and configures extended advertising parameters.
Custom payload and device name are applied during initialization.
Dynamic Advertising Interval:
The advertising interval can be modified on the fly. Use the 's' key to increase the interval (resulting in slower transmissions) and 'f' to decrease it (faster transmissions).
Display Modes:
Press 'p' to display detailed payload information.
Press 'g' to display extended advertising configuration (GACP details).
Smooth Display Update:
The display update thread refreshes at a high rate to provide near-flicker-free updates.
Testing:
The system has been tested to reboot the device, configure the advertising payload, and dynamically adjust the advertising interval. Keyboard inputs properly switch display modes and adjust the transmission rate.

Conclusion:
With these changes, the system is now fully prepared for the experimental design phase. Further improvements (e.g., advanced display handling) can be iterated based on experimental feedback.